### PR TITLE
Bug-fix: Handle OAuth cancellation with toast notifications

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import { AuthProvider } from '@/components/providers/AuthProvider';
+import { Toaster } from 'react-hot-toast';
 
 export const metadata: Metadata = {
   title: 'Profile Élegante',
@@ -18,6 +19,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <AuthProvider>
           {children}
         </AuthProvider>
+        <Toaster position="bottom-center" /> {/* the Toaster component */}
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import Hero from "../components/hero/Hero";
+import React from 'react';
+import { Suspense } from 'react';
+import Hero from '@/components/hero/Hero';
 
 export default function Home() {
   return (
-    <>
+    <Suspense fallback={<div className="w-full h-screen bg-black" />}>
       <Hero />
-    </>
+    </Suspense>
   );
 }

--- a/components/auth/AuthModal.jsx
+++ b/components/auth/AuthModal.jsx
@@ -4,24 +4,17 @@ import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { FaGoogle, FaTimes } from 'react-icons/fa';
 import { signIn } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
 
 const AuthModal = ({ isOpen, onClose }) => {
   const [loading, setLoading] = useState(false);
-  const router = useRouter();
 
   const handleMethodSelect = async (provider) => {
-    try {
-      setLoading(true);
-      await signIn(provider, {
-        callbackUrl: '/builder',
-        redirect: true
-      });
-    } catch (error) {
-      console.error('Authentication error:', error);
-      setLoading(false);
-      // Could add user notification here in the future
-    }
+    setLoading(true);
+    await signIn(provider, {
+      callbackUrl: '/builder',
+      redirect: true
+    });
+    setLoading(false);
   };
 
   if (!isOpen) return null;

--- a/components/hero/Hero.jsx
+++ b/components/hero/Hero.jsx
@@ -1,8 +1,9 @@
 "use client";
 
 import React, { useRef, useEffect, useState } from "react";
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
+import toast from 'react-hot-toast';
 import { Inter, Playfair_Display } from 'next/font/google';
 import AuthModal from '../auth/AuthModal';
 import LogoutLoader from '../auth/LogoutLoader';
@@ -30,11 +31,15 @@ export default function Hero() {
     
     const router = useRouter();
     const { data: session, status } = useSession();
+    const searchParams = useSearchParams();
 
     // Track authentication status changes
     useEffect(() => {
-        // Authentication status tracking for component state
-    }, [session, status]);
+        const error = searchParams.get('error');
+        if (error) {
+            toast.error('Sign-in was canceled. Please try again.');
+        }
+    }, [searchParams]);
 
     useEffect(() => {
         // Handle video loading state with faster detection

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "next-auth": "^4.24.11",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hot-toast": "^2.6.0",
         "react-icons": "^5.3.0",
         "react-simple-typewriter": "^5.0.1",
         "tailwindcss-animate": "^1.0.7",
@@ -3453,6 +3454,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -4986,6 +4996,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next-auth": "^4.24.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.6.0",
     "react-icons": "^5.3.0",
     "react-simple-typewriter": "^5.0.1",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
closes #14 

This resolves the Google Sign-In cancellation bug. It replaces the previous indefinite loading state with a `react-hot-toast` notification that informs the user of the cancellation.

Now, it correctly detects the error parameter in the URL, triggers the toast. 


@NiranjanKumar001 Please check and let me know if any changes required.


Screennshot- 
<img width="1832" height="1014" alt="image" src="https://github.com/user-attachments/assets/09b5f4c3-641d-4e3c-82d9-62526ec2c445" />
