### PR TITLE
fixed the resume template layout

### DIFF
--- a/app/builder/[id]/page.tsx
+++ b/app/builder/[id]/page.tsx
@@ -237,8 +237,8 @@ export default function BuilderPage() {
                       <Certification />
                     </div>
 
-                    {/* Floating Profile Pocket - Sticky at bottom */}
-                    <div className='sticky bottom-0 left-0 right-0 p-4 z-30 mt-6'>
+                    {/* Floating Profile Pocket - stick only on large screens to avoid overlap */}
+                    <div className='relative lg:sticky bottom-0 left-0 right-0 p-4 z-10 mt-6'>
                       <div
                         className='relative p-4 rounded-xl border backdrop-blur-sm'
                         style={{


### PR DESCRIPTION
### PR Title
Fix: Resume Builder sidebar profile pocket overlapping preview on tablets

### Summary
- Adjust sidebar profile pocket to be sticky only on large screens.
- Lower its stacking context to prevent overlap with the preview.
- Improves alignment and spacing between the sidebar and preview on tablets.

### Changes
- `app/builder/[id]/page.tsx`
  - Update wrapper classes: `sticky z-30` → `relative lg:sticky z-10`.

### Before
- Profile pocket was always sticky with high z-index, wedging between sidebar and preview on tablets.

### After
- Small/medium screens: pocket is non-sticky and no longer overlaps the preview.
- Large screens (`lg+`): pocket remains sticky at the bottom without obstructing content.

### Screenshots
- Please attach “Before” and “After” screenshots demonstrating the tablet layout.

### Testing
- Viewport 768–1024px: verify pocket is not sticky and does not overlap.
- Viewport ≥1024px: verify pocket is sticky and preview remains unobstructed.
- Toggle sidebar open/closed to confirm no layout shifts.

### Risks/Notes
- Low risk; Tailwind class changes only, no logic changes.

### Related Issue
- Closes #83