### PR TITLE
Added 2 templates to provide more options to users for resume

### DIFF
--- a/components/preview/Preview.jsx
+++ b/components/preview/Preview.jsx
@@ -21,6 +21,9 @@ import React, { useContext, useState, useEffect, useRef } from "react";
 import { ResumeContext } from "../../contexts/ResumeContext";
 import TemplateTwo from "./TemplateTwo";
 import TemplateFour from "./TemplateFour"
+import TemplateFive from "./TemplateFive"
+
+import TemplateSix from "./TemplateSix"
 import { useSectionTitles } from "../../contexts/SectionTitleContext";
 import {
   DndContext,
@@ -85,6 +88,18 @@ const Preview = () => {
       description: "Clean and ATS friendly",
       icon: FaTh,
     },
+    {
+    id: "template5",
+    name: "Fancy Template",
+    description: "New modern layout",
+    icon: FaFileAlt,
+  },
+  {
+    id: "template6",
+    name: "Smart Template",
+    description: "clean layout with divisions",
+    icon: FaFileAlt,
+  },
   ];
 
   const defaultSections = [
@@ -398,7 +413,10 @@ const Preview = () => {
         </div>
       </div>
       <A4PageWrapper>
-        {currentTemplate === "template1" ? (
+  {(() => {
+    switch (currentTemplate) {
+      case "template1":
+        return (
           <ClassicTemplate
             resumeData={resumeData}
             sectionOrder={sectionOrder}
@@ -408,7 +426,9 @@ const Preview = () => {
             icons={icons}
             setResumeData={setResumeData}
           />
-        ) : currentTemplate === "template2" ? (
+        );
+      case "template2":
+        return (
           <TemplateTwo
             namedata={resumeData.name}
             positionData={resumeData.position}
@@ -431,7 +451,33 @@ const Preview = () => {
             resumeData={resumeData}
             setResumeData={setResumeData}
           />
-        ) : (
+        );
+      case "template5":
+        return (
+          <TemplateFive
+            resumeData={resumeData}
+            sectionOrder={sectionOrder}
+            enabledSections={enabledSections}
+            handleDragEnd={handleDragEnd}
+            sensors={sensors}
+            icons={icons}
+            setResumeData={setResumeData}
+          />
+        );
+      case "template6":
+        return (
+          <TemplateSix
+            resumeData={resumeData}
+            sectionOrder={sectionOrder}
+            enabledSections={enabledSections}
+            handleDragEnd={handleDragEnd}
+            sensors={sensors}
+            icons={icons}
+            setResumeData={setResumeData}
+          />
+        );
+      default:
+        return (
           <TemplateFour
             resumeData={resumeData}
             sectionOrder={sectionOrder}
@@ -441,8 +487,12 @@ const Preview = () => {
             icons={icons}
             setResumeData={setResumeData}
           />
-        )}
-      </A4PageWrapper>
+        );
+    }
+  })()}
+</A4PageWrapper>
+
+
     </div>
   );
 };

--- a/components/preview/TemplateFive.jsx
+++ b/components/preview/TemplateFive.jsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { FaExternalLinkAlt } from "react-icons/fa";
+import { MdEmail, MdLocationOn, MdPhone } from "react-icons/md";
+import { GiGraduateCap } from "react-icons/gi";
+import { BiBriefcase, BiBookAlt, BiCodeAlt } from "react-icons/bi";
+import DateRange from "../utility/DateRange";
+import { DndContext, closestCenter } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import Link from "next/link";
+import { useSectionTitles } from "../../contexts/SectionTitleContext";
+import { SortableItem, SortableSection } from "./Preview";
+import { useEffect, useState } from "react";
+import { arrayMove } from "@dnd-kit/sortable";
+
+
+const TemplateFive = ({
+  resumeData,
+  sectionOrder,
+  enabledSections,
+  handleDragEnd,
+  sensors,
+  icons,
+  setResumeData,
+}) => {
+  const { customSectionTitles } = useSectionTitles();
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const handleItemDragEnd = (event, sectionType) => {
+    const { active, over } = event;
+
+    if (active.id !== over?.id && setResumeData) {
+      const updateArray = (arr) =>
+        arrayMove(
+          arr,
+          parseInt(active.id.split("-")[1]),
+          parseInt(over.id.split("-")[1])
+        );
+      if (sectionType === "projects")
+        setResumeData((prev) => ({
+          ...prev,
+          projects: updateArray(resumeData.projects),
+        }));
+      if (sectionType === "experience")
+        setResumeData((prev) => ({
+          ...prev,
+          workExperience: updateArray(resumeData.workExperience),
+        }));
+    }
+  };
+
+  const sections = [
+    { id: "summary", title: "Professional Summary", content: resumeData.summary },
+    { id: "experience", title: "Experience", content: resumeData.workExperience },
+    { id: "projects", title: "Projects", content: resumeData.projects },
+  ];
+
+  const sidebarSections = [
+    {
+      id: "education",
+      title: "Education",
+      content: resumeData.education,
+      icon: <GiGraduateCap />,
+    },
+    {
+      id: "skills",
+      title: "Technical Skills",
+      content: resumeData.skills.filter((s) => s.title !== "Soft Skills"),
+      icon: <BiCodeAlt />,
+    },
+    {
+      id: "softSkills",
+      title: "Soft Skills",
+      content: resumeData.skills.find((s) => s.title === "Soft Skills")?.skills || [],
+      icon: <BiBookAlt />,
+    },
+    { id: "languages", title: "Languages", content: resumeData.languages, icon: <BiBookAlt /> },
+    {
+      id: "certifications",
+      title: "Certifications",
+      content: resumeData.certifications,
+      icon: <BiBookAlt />,
+    },
+  ];
+
+  const orderedSections = sectionOrder
+    .map((id) => sections.find((s) => s.id === id))
+    .filter((s) => s && enabledSections[s.id]);
+
+  const renderMainSection = (section) => {
+    switch (section.id) {
+      case "summary":
+        return (
+          <div className="mb-3 print:mb-2">
+            <h2 className="section-title-main flex items-center gap-1 text-black font-bold pb-0.5 mb-1 border-b border-gray-900">
+              <BiBookAlt className="w-4 h-4" />{" "}
+              {customSectionTitles.summary || "Professional Summary"}
+            </h2>
+            <p className="text-gray-800 text-justify text-sm leading-snug">
+              {section.content}
+            </p>
+          </div>
+        );
+      case "experience":
+        return (
+          <div className="mb-3 print:mb-2">
+            <h2 className="section-title-main flex items-center gap-1 text-black font-bold pb-0.5 mb-2 border-b border-gray-900">
+              <BiBriefcase className="w-4 h-4" />{" "}
+              {customSectionTitles.experience || "Professional Experience"}
+            </h2>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={(e) => handleItemDragEnd(e, "experience")}
+            >
+              <SortableContext
+                items={resumeData.workExperience.map((_, i) => `work-${i}`)}
+                strategy={verticalListSortingStrategy}
+              >
+                {resumeData.workExperience.map((item, index) => (
+                  <SortableItem key={`work-${index}`} id={`work-${index}`}>
+                    <div className="relative pl-4 mb-2">
+                      <div className="absolute left-0 top-1 w-2 h-2 bg-black rounded-full"></div>
+                      <div className="p-0 bg-white border-l border-gray-300 ml-1">
+                        <h3 className="font-bold text-gray-900 text-sm leading-snug">
+                          {item.position} | {item.company}
+                        </h3>
+                        <DateRange
+                          startYear={item.startYear}
+                          endYear={item.endYear}
+                          id={`exp-${index}`}
+                          className="text-xs text-gray-700 block"
+                        />
+                        <p className="text-gray-800 mt-1 text-sm leading-snug">
+                          {item.description}
+                        </p>
+                        {item.keyAchievements && (
+                          <ul className="list-disc list-inside text-gray-800 mt-1 ml-3 text-sm leading-snug">
+                            {item.keyAchievements
+                              .split("\n")
+                              .filter((a) => a.trim())
+                              .map((a, idx) => <li key={idx}>{a}</li>)}
+                          </ul>
+                        )}
+                      </div>
+                    </div>
+                  </SortableItem>
+                ))}
+              </SortableContext>
+            </DndContext>
+          </div>
+        );
+      case "projects":
+        return (
+          <div className="mb-3 print:mb-2">
+            <h2 className="section-title-main flex items-center gap-1 text-black font-bold pb-0.5 mb-2 border-b border-gray-900">
+              <BiCodeAlt className="w-4 h-4" />{" "}
+              {customSectionTitles.projects || "Projects"}
+            </h2>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={(e) => handleItemDragEnd(e, "projects")}
+            >
+              <SortableContext
+                items={resumeData.projects.map((_, i) => `project-${i}`)}
+                strategy={verticalListSortingStrategy}
+              >
+                {resumeData.projects.map((item, index) => (
+                  <SortableItem key={`project-${index}`} id={`project-${index}`}>
+                    <div className="relative pl-4 mb-2">
+                      <div className="absolute left-0 top-1 w-2 h-2 bg-black rounded-full"></div>
+                      <div className="p-0 bg-white border-l border-gray-300 ml-1">
+                        <h3 className="font-bold text-gray-900 text-sm leading-snug flex items-center gap-1">
+                          {item.name}
+                          {item.link && (
+                            <Link
+                              href={item.link}
+                              target="_blank"
+                              className="text-gray-600 hover:text-black"
+                            >
+                              <FaExternalLinkAlt className="w-3 h-3" />
+                            </Link>
+                          )}
+                        </h3>
+                        <DateRange
+                          startYear={item.startYear}
+                          endYear={item.endYear}
+                          id={`proj-${index}`}
+                          className="text-xs text-gray-700 block"
+                        />
+                        <p className="text-gray-800 mt-1 text-sm leading-snug">
+                          {item.description}
+                        </p>
+                      </div>
+                    </div>
+                  </SortableItem>
+                ))}
+              </SortableContext>
+            </DndContext>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const renderSidebarSection = (section) => {
+    if (!section.content || (Array.isArray(section.content) && section.content.length === 0))
+      return null;
+
+    return (
+      <div className="mb-3 print:mb-2">
+        <h2 className="flex items-center gap-1 text-black font-bold pb-0.5 mb-1 border-b border-gray-900">
+          <span className="text-black">{section.icon}</span>{" "}
+          <span className="text-sm uppercase">
+            {customSectionTitles[section.id] || section.title}
+          </span>
+        </h2>
+
+        {section.id === "education" ? (
+          <ul className="text-gray-800 text-sm space-y-1">
+            {resumeData.education.map((item, idx) => (
+              <li key={idx}>
+                <p className="font-semibold">{item.school}</p>
+                <div className="text-xs text-gray-700">
+                  {item.degree} -{" "}
+                  <DateRange
+                    startYear={item.startYear}
+                    endYear={item.endYear}
+                    id={`edu-range-${idx}`}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : Array.isArray(section.content) ? (
+          section.id === "skills" || section.id === "softSkills" || section.id === "languages" ? (
+            <div className="text-gray-800 text-sm leading-snug">
+              {section.id === "skills" ? (
+                section.content.map((group, idx) => (
+                  <div key={idx} className="mb-1">
+                    <p className="font-semibold text-xs">{group.title}:</p>
+                    <p className="text-sm">{group.skills?.join(", ")}</p>
+                  </div>
+                ))
+              ) : (
+                <p>
+                  {section.content
+                    .map((s) => (typeof s === "string" ? s : s.skills?.join(", ")))
+                    .join(", ")}
+                </p>
+              )}
+            </div>
+          ) : (
+            <ul className="list-disc list-inside text-gray-800 text-sm ml-2 space-y-1">
+              {section.content.map((item, idx) => (
+                <li key={idx}>
+                  {typeof item === "string" ? item : item.school || item.name}
+                </li>
+              ))}
+            </ul>
+          )
+        ) : (
+          <p className="text-gray-800 text-sm">{section.content}</p>
+        )}
+      </div>
+    );
+  };
+
+  if (!isClient)
+    return <div className="animate-pulse p-4 bg-white h-full w-full"></div>;
+
+  return (
+    <div className="w-full h-full bg-white p-6 print:p-0">
+      {/* Header */}
+      <div className="text-center mb-4 border-b border-gray-900 pb-1">
+        <h1 className="text-2xl font-bold text-gray-900 inline-block px-0 py-0">
+          {resumeData.name}
+        </h1>
+        <h2 className="text-base font-semibold text-gray-800 mt-0.5">
+          {resumeData.position}
+        </h2>
+
+        <div className="flex justify-center flex-wrap gap-x-4 gap-y-0.5 mt-1 text-gray-700 text-sm">
+          {resumeData.contactInformation && (
+            <div className="flex items-center gap-1">
+              <MdPhone className="w-3 h-3 text-gray-700" />
+              <span>{resumeData.contactInformation}</span>
+            </div>
+          )}
+          {resumeData.email && (
+            <div className="flex items-center gap-1">
+              <MdEmail className="w-3 h-3 text-gray-700" />
+              <span>{resumeData.email}</span>
+            </div>
+          )}
+          {resumeData.address && (
+            <div className="flex items-center gap-1">
+              <MdLocationOn className="w-3 h-3 text-gray-700" />
+              <span>{resumeData.address}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Two-column layout */}
+      <div className="flex flex-col md:flex-row gap-4 print:gap-3">
+        <div className="w-full md:w-1/3 p-0 bg-white">
+          {sidebarSections.map((section) => (
+            <div key={section.id}>{renderSidebarSection(section)}</div>
+          ))}
+        </div>
+
+        <div className="w-full md:w-2/3 p-0 border-l border-gray-300 pl-4 print:pl-3">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={orderedSections.map((s) => s.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {orderedSections.map((section) => (
+                <SortableSection key={section.id} id={section.id}>
+                  {renderMainSection(section)}
+                </SortableSection>
+              ))}
+            </SortableContext>
+          </DndContext>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TemplateFive;

--- a/components/preview/TemplateSix.jsx
+++ b/components/preview/TemplateSix.jsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { FaExternalLinkAlt } from "react-icons/fa";
+import { MdEmail, MdLocationOn, MdPhone, MdLink } from "react-icons/md";
+import { GiGraduateCap } from "react-icons/gi";
+import { BiBriefcase, BiBookAlt, BiCodeAlt, BiStar } from "react-icons/bi";
+import DateRange from "../utility/DateRange";
+import { DndContext, closestCenter } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import Link from "next/link";
+import { useSectionTitles } from "../../contexts/SectionTitleContext";
+import { SortableItem, SortableSection } from "./Preview";
+import { useEffect, useState } from "react";
+import { arrayMove } from "@dnd-kit/sortable";
+
+
+const TemplateSix = ({
+  resumeData,
+  sectionOrder,
+  enabledSections,
+  handleDragEnd,
+  sensors,
+  setResumeData,
+}) => {
+  const { customSectionTitles } = useSectionTitles();
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const handleItemDragEnd = (event, sectionType) => {
+    const { active, over } = event;
+
+    if (active.id !== over?.id && setResumeData) {
+      const updateArray = (arr) =>
+        arrayMove(
+          arr,
+          parseInt(active.id.split("-")[1]),
+          parseInt(over.id.split("-")[1])
+        );
+      if (sectionType === "projects")
+        setResumeData((prev) => ({ ...prev, projects: updateArray(resumeData.projects) }));
+      if (sectionType === "experience")
+        setResumeData((prev) => ({ ...prev, workExperience: updateArray(resumeData.workExperience) }));
+      if (sectionType === "education")
+        setResumeData((prev) => ({ ...prev, education: updateArray(resumeData.education) }));
+    }
+  };
+
+  const sectionsMap = {
+    summary: { id: "summary", title: "Professional Summary", content: resumeData.summary, icon: <BiBookAlt /> },
+    experience: { id: "experience", title: "Experience", content: resumeData.workExperience, icon: <BiBriefcase /> },
+    projects: { id: "projects", title: "Projects", content: resumeData.projects, icon: <BiCodeAlt /> },
+    education: { id: "education", title: "Education", content: resumeData.education, icon: <GiGraduateCap /> },
+    skills: { id: "skills", title: "Technical Skills", content: resumeData.skills.filter(s => s.title !== "Soft Skills"), icon: <BiCodeAlt /> },
+    softSkills: { id: "softSkills", title: "Soft Skills", content: resumeData.skills.find(s => s.title === "Soft Skills")?.skills || [], icon: <BiStar /> },
+    languages: { id: "languages", title: "Languages", content: resumeData.languages, icon: <BiBookAlt /> },
+    certifications: { id: "certifications", title: "Certifications", content: resumeData.certifications, icon: <BiStar /> },
+  };
+
+  const orderedSections = sectionOrder
+    .map(id => sectionsMap[id])
+    .filter(s => s && enabledSections[s.id] && s.content && (Array.isArray(s.content) ? s.content.length > 0 : s.content.length > 0));
+
+  // Component to render the section header (Title + Line)
+  const SectionHeader = ({ id, icon, defaultTitle }) => (
+    <div className="mb-2 print:mb-1">
+      <h2 className="text-lg font-bold uppercase tracking-wider text-gray-900 mb-1">
+        {customSectionTitles[id] || defaultTitle}
+      </h2>
+      <div className="w-full h-0.5 bg-gray-500 mb-3 print:mb-2"></div>
+    </div>
+  );
+
+  const renderSectionContent = (section) => {
+    switch (section.id) {
+      case "summary":
+        return (
+          <div className="text-gray-700 text-sm leading-snug">
+            {section.content}
+          </div>
+        );
+      case "experience":
+        return (
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={(e) => handleItemDragEnd(e, "experience")}>
+            <SortableContext items={resumeData.workExperience.map((_, i) => `work-${i}`)} strategy={verticalListSortingStrategy}>
+              {resumeData.workExperience.map((item, index) => (
+                <SortableItem key={`work-${index}`} id={`work-${index}`}>
+                  <div className="mb-3 print:mb-2">
+                    <div className="flex justify-between items-start text-sm">
+                      <h3 className="font-bold text-gray-900 leading-tight">
+                        {item.position}
+                        <span className="font-normal text-gray-700 block italic">{item.company} | {item.location}</span>
+                      </h3>
+                      <DateRange
+                        startYear={item.startYear}
+                        endYear={item.endYear}
+                        id={`exp-range-${index}`}
+                        className="text-xs font-semibold text-gray-600 flex-shrink-0 ml-2 pt-1"
+                      />
+                    </div>
+                    {item.description && <p className="text-gray-700 text-sm mt-1 leading-snug">{item.description}</p>}
+                    {item.keyAchievements && (
+                      <ul className="list-disc list-outside text-gray-700 mt-0.5 ml-5 text-sm leading-snug">
+                        {item.keyAchievements.split("\n").filter(a => a.trim()).map((a, idx) => <li key={idx}>{a}</li>)}
+                      </ul>
+                    )}
+                  </div>
+                </SortableItem>
+              ))}
+            </SortableContext>
+          </DndContext>
+        );
+      case "projects":
+        return (
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={(e) => handleItemDragEnd(e, "projects")}>
+            <SortableContext items={resumeData.projects.map((_, i) => `project-${i}`)} strategy={verticalListSortingStrategy}>
+              {resumeData.projects.map((item, index) => (
+                <SortableItem key={`project-${index}`} id={`project-${index}`}>
+                  <div className="mb-3 print:mb-2">
+                    <div className="flex justify-between items-start text-sm">
+                      <h3 className="font-bold text-gray-900 leading-tight flex items-center gap-2">
+                        {item.name}
+                        {item.link && <Link href={item.link} target="_blank" className="text-gray-500 hover:text-black"><FaExternalLinkAlt className="w-3 h-3" /></Link>}
+                      </h3>
+                      <DateRange
+                        startYear={item.startYear}
+                        endYear={item.endYear}
+                        id={`proj-range-${index}`}
+                        className="text-xs font-semibold text-gray-600 flex-shrink-0 ml-2 pt-1"
+                      />
+                    </div>
+                    <p className="text-gray-700 text-sm mt-0.5 leading-snug">{item.description}</p>
+                    {item.technologies && <p className="text-xs text-gray-600 mt-0.5">**Tech Stack:** {item.technologies}</p>}
+                  </div>
+                </SortableItem>
+              ))}
+            </SortableContext>
+          </DndContext>
+        );
+      case "education":
+        return (
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={(e) => handleItemDragEnd(e, "education")}>
+            <SortableContext items={resumeData.education.map((_, i) => `education-${i}`)} strategy={verticalListSortingStrategy}>
+              {resumeData.education.map((item, index) => (
+                <SortableItem key={`education-${index}`} id={`education-${index}`}>
+                  <div className="mb-3 print:mb-2">
+                    <div className="flex justify-between items-start text-sm">
+                      <h3 className="font-bold text-gray-900 leading-tight">
+                        {item.degree}
+                        <span className="font-normal text-gray-700 block italic">{item.school} | {item.location}</span>
+                      </h3>
+                      <DateRange
+                        startYear={item.startYear}
+                        endYear={item.endYear}
+                        id={`edu-range-${index}`}
+                        className="text-xs font-semibold text-gray-600 flex-shrink-0 ml-2 pt-1"
+                      />
+                    </div>
+                  </div>
+                </SortableItem>
+              ))}
+            </SortableContext>
+          </DndContext>
+        );
+      case "skills":
+      case "softSkills":
+      case "languages":
+      case "certifications":
+        const listContent = Array.isArray(section.content)
+          ? section.content.map(s => typeof s === "string" ? s : s.skills?.join(", ") || s.name).join(" | ")
+          : section.content;
+        return <p className="text-gray-700 text-sm leading-snug font-semibold">{listContent}</p>;
+
+      default:
+        return null;
+    }
+  };
+
+  if (!isClient) return <div className="animate-pulse p-4 bg-white h-full w-full"></div>;
+
+  return (
+    <div className="w-full h-full bg-white p-6 print:p-0 font-serif">
+      {/* Header - Solid Black/Dark Gray Block */}
+      <div className="bg-gray-800 text-white p-4 mb-4 print:p-2 print:mb-2">
+        <h1 className="text-4xl font-extrabold tracking-tight mb-1">
+          {resumeData.name}
+        </h1>
+        <h2 className="text-xl font-light mb-3 opacity-90">
+          {resumeData.position}
+        </h2>
+        
+        {/* Contact Info - Compact and White/Light Gray */}
+        <div className="flex flex-wrap gap-x-5 gap-y-1 text-sm opacity-80">
+          {resumeData.contactInformation && (
+            <div className="flex items-center gap-1">
+              <MdPhone className="w-4 h-4" /> <span>{resumeData.contactInformation}</span>
+            </div>
+          )}
+          {resumeData.email && (
+            <div className="flex items-center gap-1">
+              <MdEmail className="w-4 h-4" /> <span>{resumeData.email}</span>
+            </div>
+          )}
+          {resumeData.address && (
+            <div className="flex items-center gap-1">
+              <MdLocationOn className="w-4 h-4" /> <span>{resumeData.address}</span>
+            </div>
+          )}
+          {/* Example for a link (LinkedIn/Portfolio) */}
+          {resumeData.linkedin && (
+            <div className="flex items-center gap-1">
+              <MdLink className="w-4 h-4" /> <Link href={resumeData.linkedin} target="_blank" className="underline">{resumeData.linkedin}</Link>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Main Content - Single Column */}
+      <div className="px-4 print:px-0">
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={orderedSections.map(s => s.id)} strategy={verticalListSortingStrategy}>
+            {orderedSections.map(section => (
+              <SortableSection key={section.id} id={section.id}>
+                <div className="mb-4 print:mb-2">
+                  <SectionHeader
+                    id={section.id}
+                    icon={section.icon}
+                    defaultTitle={section.title}
+                  />
+                  {renderSectionContent(section)}
+                </div>
+              </SortableSection>
+            ))}
+          </SortableContext>
+        </DndContext>
+      </div>
+    </div>
+  );
+};
+
+export default TemplateSix;


### PR DESCRIPTION
feat: add two new templates

Added 2 new templates-
1. TemplateFive: Two-column modern layout with sidebar for education and skills, drag-and-drop reordering, and responsive design.
2. TemplateSix: Single-column bold layout with dark header, clean typography, and support for draggable sections.

Both templates are integrated with @dnd-kit, useSectionTitles, and optimized for print and responsiveness.